### PR TITLE
#19 Update environment variable from museumos-prod to xos.

### DIFF
--- a/config.tmpl.env
+++ b/config.tmpl.env
@@ -1,4 +1,4 @@
-XOS_API_ENDPOINT=https://museumos-prod.acmi.net.au/api/
+XOS_API_ENDPOINT=https://xos.acmi.net.au/api/
 AUTH_TOKEN=
 XOS_PLAYLIST_ID=1
 XOS_MEDIA_PLAYER_ID=1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -55,7 +55,7 @@ def mocked_requests_get(*args, **kwargs):
         def raise_for_status(self):
             return None
 
-    if args[0].startswith('https://museumos-prod.acmi.net.au/api/playlists/'):
+    if args[0].startswith('https://xos.acmi.net.au/api/playlists/'):
         return MockResponse(file_to_string_strip_new_lines('data/playlist.json'), 200)
 
     return MockResponse(None, 404)
@@ -76,7 +76,7 @@ def mocked_requests_post(*args, **kwargs):
         def raise_for_status(self):
             return None
 
-    if args[0].startswith('https://museumos-prod.acmi.net.au/api/taps/'):
+    if args[0].startswith('https://xos.acmi.net.au/api/taps/'):
         return MockResponse(file_to_string_strip_new_lines('data/xos_tap.json'), 201)
 
     return MockResponse(None, 404)


### PR DESCRIPTION
*Resolves issue #19*

Rename references from museumos-prod to xos.

### Acceptance Criteria
- [x] Rename references from https://museumos-prod.acmi.net.au to https://xos.acmi.net.au

### Relevant design files
* None

### Testing instructions
1. Once XOS has been updated, restart this playlist label and see that it connects to XOS: https://dashboard.balena-cloud.com/apps/1529802/devices

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
