### PR TITLE
#1297 Move fixtures to conftest.py, declare fixtures using @pytest.ma…

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=alsaaudio
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS, migrations, settings, venv, Makefile, Dockerfile, Dockerfile.template, Dockerfile.raspberrypi4-64, requirements, resources, tests, setupJest.js, package.json, package-lock.json, node_modules, scripts, .git, __pycache__, npm-debug.log, test
+ignore=CVS, migrations, settings, venv, Makefile, Dockerfile, Dockerfile.template, Dockerfile.raspberrypi4-64, requirements, resources, setupJest.js, package.json, package-lock.json, node_modules, scripts, .git, __pycache__, npm-debug.log
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
@@ -140,7 +140,8 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
         # ACMI entries
-        missing-docstring
+        missing-docstring,
+        no-self-use
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -297,7 +298,7 @@ dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore.
-ignored-argument-names=_.*|^ignored_|^unused_
+ignored-argument-names=_.*|^ignored_|^unused_|args|kwargs
 
 # Tells whether we should check for unused import in __init__ files.
 init-import=no

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,21 @@
 import pytest
+from peewee import SqliteDatabase
 
 from app import main
+from app.main import Message
 
 
 @pytest.fixture
 def app():
     return main.app
+
+
+@pytest.fixture
+def database():
+    """
+    Setup the test database.
+    """
+    test_db = SqliteDatabase(':memory:')
+    test_db.bind([Message], bind_refs=False, bind_backrefs=False)
+    test_db.connect()
+    test_db.create_tables([Message])


### PR DESCRIPTION
…rk.usefixtures and avoid passing patched objects as arguments if they won't be used

*Resolves issue ACMILabs/xos#1297*

Pylint does not ignore tests anymore and tests now pass linting. Some changes in tests so that they pass linting:

- Fixtures are created in `conftest.py` instead of `tests.py`. This helps avoid `redefined-outer-name`
- Fixtures are now declared using `@pytest.mark.usefixtures`. Helps avoid `unused-argument`.
- Patch decorators are now in the form `@patch('requests.get', MagicMock(side_effect=mocked_requests_get))` which does not pass an argument to the function, thus avoiding `unused-argument`.

### Acceptance Criteria
- [X] Linter does not ignore tests
- [X] Tests pass linting

### Relevant design files
* None

### Testing instructions
1. Spin up the container `cd development` and `docker-compose up`
2. Run `docker exec -ti playlistlabel pylint --reports=y *`, make sure that linting passes and check that test files are listed in the "External dependencies" section in parentheses.

### DoD
For requester to complete:
- [X] All acceptance criteria are met
~New logic has been documented~
~New logic has appropriate unit tests~
~Changelog has been updated if necessary~
~Deployment / migration instruction have been updated if required~
