### PR TITLE
#27 Fix screen static by setting a new mode based on Raspbian settings.

### DIFF
--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -12,7 +12,6 @@ RUN install_packages \
   raspberrypi-ui-mods rpd-icons \
   gtk2-engines-clearlookspix \
   matchbox-keyboard \
-  unclutter \
   xinput
 
 # disable lxpolkit popup warning

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,8 +10,7 @@ RUN install_packages \
   xinit lxsession desktop-file-utils \
   raspberrypi-ui-mods rpd-icons \
   gtk2-engines-clearlookspix \
-  matchbox-keyboard \
-  unclutter
+  matchbox-keyboard
 
 # disable lxpolkit popup warning
 RUN mv /usr/bin/lxpolkit /usr/bin/lxpolkit.bak

--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -4,7 +4,7 @@ rm /tmp/.X0-lock &>/dev/null || true
 
 echo "Starting X in 2 seconds"
 sleep 2
-startx &
+startx -- -nocursor &
 sleep 20
 
 # Set the display to use
@@ -37,9 +37,6 @@ xrandr --newmode "1920x720_60.00"  100.98  1920 2008 2052 2200  720 724 729 765 
 xrandr --addmode HDMI-1 "1920x720_60.00"
 xrandr --output HDMI-1 --mode "1920x720_60.00"
 fi
-
-# Hide the cursor
-unclutter -display :0 -idle 0.1 &
 
 # Start Flask
 python -u -m app.main &

--- a/scripts/pi4.sh
+++ b/scripts/pi4.sh
@@ -9,7 +9,7 @@ export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 # start desktop manager
 echo "STARTING X"
 sleep 2
-startx &
+startx -- -nocursor &
 sleep 20
 
 # Set the display to use
@@ -42,9 +42,6 @@ xrandr --newmode "1920x720_60.00"  100.98  1920 2008 2052 2200  720 724 729 765 
 xrandr --addmode HDMI-1 "1920x720_60.00"
 xrandr --output HDMI-1 --mode "1920x720_60.00"
 fi
-
-# Hide the cursor
-unclutter -display :0 -idle 0.1 &
 
 # Start Flask
 python3 -u -m app.main &


### PR DESCRIPTION
*Resolves issue #27*

Fix screen static by setting a new mode based on Raspbian settings.

### Acceptance Criteria
- [x] Use `xrandr` to set these successful settings (which were found on a Raspbian image by running `xrandr -q`)

### Relevant design files
* None

### Testing instructions
1. See that the portrait label has no static on Glen's desk

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~