### PR TITLE
#43 Robust RabbitMQ connection and improved error sending to sentry.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -209,7 +209,7 @@ def test_send_error_sends_on_repetition_and_repeat_every_1_second(capture_except
         playlist_label.send_error('rmq_conn', None, on_rep=5, every=1, units='seconds')
     assert capture_exception.call_count == 1
 
-    time.sleep(1)
+    time.sleep(1.5)
 
     # make sure the error is sent after 1 second
     playlist_label.send_error('rmq_conn', None, on_rep=5, every=1, units='seconds')


### PR DESCRIPTION
Resolves #43

- Created function that deals with sending too many errors to Sentry by keeping a history of consecutive errors
- I'm making the playlist label not send connection errors as soon as they happen but rather at the 3rd consecutive error and subsequent errors every hour if it hasn't been fixed yet.
- Refactored RabbitMQ connection so that connection is restarted if there is a network problem

### Acceptance Criteria
- [X] Fix Sentry spamming issue

### Relevant design files
* None

### Testing instructions
This is a bit tough to test as we would need to create network errors. The way I've tested it is by making the devices connect to a local network without access to the VPN and pointing to a local XOS instance, so that they don't have access to RabbitMQ. So:

1. Deploy this branch to a playlist label that connects to a local network without access to VPN
2. Set the `XOS_API_ENDPOINT` to `http://<your-ip>:8000/api/`
3. Set the appropriate `SENTRY_ID`
4. Check the logs that this message appears "Error connecting to RabbitMQ server: ..." for three times before an error is sent to Sentry
5. Check that an error is sent to Sentry https://sentry.io/organizations/ACMI/issues/?project=1524888
6. Check that although the logs keep showing the message "Error connecting to RabbitMQ server: ...", no more errors are sent to Sentry
7. If you have time, wait for an hour with the device connected to the internet and check that another Sentry error was sent.

### DoD
For requester to complete:
- [X] All acceptance criteria are met
- [X] New logic has been documented
- [X] New logic has appropriate unit tests
~Changelog has been updated if necessary~
~Deployment / migration instruction have been updated if required~
