### PR TITLE
#48 Render title_annotation if present

### DIFF
--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -58,6 +58,7 @@ export default class PlaylistLabelRenderer {
       .then((jsonData) => {
         this.state.playlistJson = jsonData;
         this.subscribeToMediaPlayer(jsonData);
+        this.addTitleAnnotation(jsonData.playlist_labels[0].label.work);
       })
       .catch((error) => console.error(error)); // eslint-disable-line no-console
   }
@@ -123,7 +124,9 @@ export default class PlaylistLabelRenderer {
           this.state.nextLabelId = labels[(index + 1) % labels.length].label.id;
 
           // Update the label fields with the currently playing data
-          document.getElementById("title").innerHTML = element.label.title;
+          const title = document.getElementById("title");
+          title.innerHTML = element.label.title;
+          this.addTitleAnnotation(element.label.work);
           document.getElementById("subtitles").innerHTML =
             element.label.subtitles;
           document.getElementById("content0").innerHTML =
@@ -180,6 +183,20 @@ export default class PlaylistLabelRenderer {
           this.state.isAnimatingCollect = false;
         }.bind(this),
         3500
+      );
+    }
+  }
+
+  addTitleAnnotation(work) {
+    // If a title_annotation exists, add it to the end of the title
+    if (work && work.title_annotation) {
+      const title = document.getElementById("title");
+      const titleAnnotation = document.createElement("span");
+      titleAnnotation.className = "title_annotation";
+      titleAnnotation.innerHTML = work.title_annotation;
+      title.innerHTML = title.innerHTML.replace(
+        /<\/p>/g,
+        `${titleAnnotation.outerHTML}</p>`
       );
     }
   }

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -80,6 +80,14 @@ body {
   line-height: 65px;
 }
 
+.title_annotation {
+  font-family: FaktPro;
+  font-size: 2.5rem;
+  font-weight: normal;
+  padding-left: 1rem;
+  text-transform: lowercase;
+}
+
 .subtitles {
   font-size: 28px;
   line-height: 39px;

--- a/tests/data/message_with_title_annotation.json
+++ b/tests/data/message_with_title_annotation.json
@@ -1,0 +1,8 @@
+{
+  "datetime": "2019-07-18T17:54:46.633928+10:00",
+  "playlist_id": 1,
+  "media_player_id": 8,
+  "label_id": 18,
+  "playback_position": 0.12073068320751,
+  "duration": 93
+}

--- a/tests/data/playlist.json
+++ b/tests/data/playlist.json
@@ -67,6 +67,7 @@
         "work": {
           "id": 49,
           "title": "Jurassic Park",
+          "title_annotation": "facsimile",
           "public_images": [
             {
                 "id": 554,

--- a/tests/js/__tests__/playlist.test.js
+++ b/tests/js/__tests__/playlist.test.js
@@ -1,6 +1,7 @@
 import PlaylistLabelRenderer from "../../../app/static/playlist";
 import playlistJson from "../../data/playlist.json";
 import messageJson from "../../data/message.json";
+import messageJsonWithTitleAnnotation from "../../data/message_with_title_annotation.json";
 
 describe("PlaylistLabelRenderer", () => {
   beforeEach(() => {
@@ -69,6 +70,7 @@ describe("PlaylistLabelRenderer", () => {
       }
     );
     expect(document.body.innerHTML).toContain(element.label.title);
+    expect(document.body.innerHTML).not.toContain("title_annotation");
     expect(document.body.innerHTML).toContain(element.label.subtitles);
     expect(document.body.innerHTML).toContain(element.label.columns[0].content);
     const elementNext = renderer.state.playlistJson.playlist_labels.find(
@@ -77,6 +79,27 @@ describe("PlaylistLabelRenderer", () => {
       }
     );
     expect(document.body.innerHTML).toContain(elementNext.label.title);
+  });
+
+  it("should include a title annotation when a message arrives", () => {
+    const messageData = {
+      payloadString: JSON.stringify(messageJsonWithTitleAnnotation),
+    };
+    const renderer = new PlaylistLabelRenderer();
+    renderer.state.playlistJson = playlistJson;
+    renderer.init();
+    renderer.onMessageArrived(messageData);
+    const element = renderer.state.playlistJson.playlist_labels.find(
+      (label) => {
+        return label.label.id === renderer.state.currentLabelId;
+      }
+    );
+    const tmp = document.createElement("div");
+    tmp.innerHTML = element.label.title;
+    expect(document.body.innerHTML).toContain(tmp.textContent);
+    expect(document.body.innerHTML).toContain(
+      element.label.work.title_annotation
+    );
   });
 
   it("should handle tap events", () => {


### PR DESCRIPTION
Resolves #48

Display title_annotation if present.

### Acceptance Criteria
- [x] Implement css to display `title_annotation` field from the works serializer next to the Title, possibly with decoration such as square brackets.
- [x] Test in landscape and portrait orientation - may need a nbsp or something to avoid awkward line breaks?

### Relevant design files
* [Design from Pip](https://images.zenhubusercontent.com/5c56ba66fd8e3861b7794f29/a5a5ce77-2cc2-465c-89b0-dae327219e65)

### Testing instructions
1. Edit `config.env` to point to `XOS_PLAYLIST_ID=46` and `XOS_API_ENDPOINT=https://xos.acmi.net.au/api/`
1. `cd development` and `docker-compose up --build`
1. Visit: http://localhost:8081 and note that `facsimile` is lowercased, and the size and spacing matches the design linked above
1. Note that it also displays nicely in portrait mode and facsimile isn't line-breaking
1. Play this on a real device and see that the facsimile is updated when a message arrives: https://dashboard.balena-cloud.com/apps/1529802/devices

Screenshots from my development machine:


### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
