### PR TITLE
#64 Fix collect label

### DIFF
--- a/app/static/common.style.css
+++ b/app/static/common.style.css
@@ -55,6 +55,7 @@ body {
 
 .progress-bar {
   width: 100%;
+  max-width: 100%;
   height: 10px;
   background-color: #757575;
   transition: 1200ms linear;

--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -256,10 +256,14 @@ export default class PlaylistLabelRenderer {
       try {
         document.querySelector(`${id} .time_to_wait`).innerHTML =
           numMinutes + unit;
-      } catch (err) {
+      } catch (error) {
         // continue regardless of error
       }
-      timeToWait += items[i].video.duration_secs;
+      try {
+        timeToWait += items[i].video.duration_secs;
+      } catch (error) {
+        // continue regardless of error
+      }
     }
   }
 

--- a/app/static/playlist.style.css
+++ b/app/static/playlist.style.css
@@ -67,6 +67,7 @@ p:last-child {
 }
 
 .collect {
+  background-color: #fff;
   color: #000;
   margin-top: 39px;
   padding: 30px 40px 24px 75px;
@@ -74,6 +75,9 @@ p:last-child {
   font-size: 23px;
   transition: background 500ms, color 500ms;
   display: inline-block;
+  position: fixed;
+  bottom: 200px;
+  left: 0;
 }
 
 .collect:before {


### PR DESCRIPTION
Resolves #64

Fix collect label to the bottom left of the label so that long headings or subtitles don't push it behind the playback progress bar.

### Acceptance Criteria
- [x] Sync changes from XOS Playlist preview
- [x] Fix the `collect` div so that long headings don't push it behind the playback position div

### Relevant design files
* None

### Testing instructions
1. Start your playlist label: `cd development` and `docker-compose up`
1. See that the `collect` label is fixed in place to the playback position bar, and long headings don't push it behind it

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required`
