### PR TITLE
#70 Fix linting and tests

### DIFF
--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -17,7 +17,7 @@ export default class PlaylistLabelRenderer {
       items: null,
       upcomingItems: null,
       isAnimatingCollect: false,
-      playbackPosition: 0
+      playbackPosition: 0,
     };
   }
 
@@ -26,33 +26,33 @@ export default class PlaylistLabelRenderer {
    * rendered page via window.initialData.
    */
   init() {
-    const id = 'id' in window.initialData ? window.initialData.id : null;
+    const id = "id" in window.initialData ? window.initialData.id : null;
     this.state.currentLabelId =
-      'current_label_id' in window.initialData
+      "current_label_id" in window.initialData
         ? window.initialData.current_label_id
         : null;
     this.state.nextLabelId =
-      'next_label_id' in window.initialData
+      "next_label_id" in window.initialData
         ? window.initialData.next_label_id
         : null;
 
     if (id != null) {
       this.fetchPlaylist(`/api/playlist/`);
     } else {
-      console.error('No valid id could be found on initial pageload.'); // eslint-disable-line no-console
+      console.error("No valid id could be found on initial pageload."); // eslint-disable-line no-console
     }
 
     if (
-      typeof window.initialData.ignore_tap_reader === 'undefined' ||
+      typeof window.initialData.ignore_tap_reader === "undefined" ||
       !window.initialData.ignore_tap_reader
     ) {
       this.handleTapMessage = this.handleTapMessage.bind(this);
-      const tapSource = new EventSource('/api/tap-source/');
+      const tapSource = new EventSource("/api/tap-source/");
       tapSource.onmessage = this.handleTapMessage;
     }
 
     if (
-      typeof window.initialData.ignore_media_player !== 'undefined' &&
+      typeof window.initialData.ignore_media_player !== "undefined" &&
       window.initialData.ignore_media_player
     ) {
       setInterval(this.autoUpdateProgress, 1000 / FPS, this);
@@ -72,7 +72,7 @@ export default class PlaylistLabelRenderer {
     document.onkeydown = this.onKeyPress.bind(this);
     window.onhashchange = this.hashChange.bind(this);
     if (
-      typeof window.initialData.ignore_media_player === 'undefined' ||
+      typeof window.initialData.ignore_media_player === "undefined" ||
       !window.initialData.ignore_media_player
     ) {
       this.subscribeToMediaPlayer(jsonData);
@@ -92,14 +92,14 @@ export default class PlaylistLabelRenderer {
   fetchPlaylist(url) {
     if (url && !window.initialData.is_preview) {
       fetch(url)
-        .then(response => {
+        .then((response) => {
           if (!response.ok) {
             throw Error(response.statusText);
           }
           return response.json();
         })
         .then(this.onPlaylistData.bind(this))
-        .catch(error => console.error(error)); // eslint-disable-line no-console
+        .catch((error) => console.error(error)); // eslint-disable-line no-console
     } else {
       this.onPlaylistData(window.initialData.playlist_json);
     }
@@ -114,8 +114,8 @@ export default class PlaylistLabelRenderer {
     const client = new Paho.MQTT.Client( // eslint-disable-line no-undef
       window.initialData.mqtt_host,
       parseInt(window.initialData.mqtt_port, 10),
-      '/ws',
-      ''
+      "/ws",
+      ""
     );
 
     // set callback handlers
@@ -134,7 +134,7 @@ export default class PlaylistLabelRenderer {
       onFailure: () => {
         // Try to re-connect again
         this.subscribeToMediaPlayer();
-      }
+      },
     });
   }
 
@@ -184,7 +184,7 @@ export default class PlaylistLabelRenderer {
 
     // make a list of items that starts with the new label
     const upcomingItems = [];
-    const startIndex = items.findIndex(item => {
+    const startIndex = items.findIndex((item) => {
       return item.label && item.label.id === labelId;
     });
     for (let i = 0; i < items.length; i++) {
@@ -204,25 +204,25 @@ export default class PlaylistLabelRenderer {
   updateMainLabelContent(item) {
     const { label } = item;
     // Update the label fields with the currently playing data
-    document.getElementById('title').innerHTML = label.title;
+    document.getElementById("title").innerHTML = label.title;
     this.addTitleAnnotation(label.work);
-    document.getElementById('subtitles').innerHTML = label.subtitles;
-    document.getElementById('content0').innerHTML = label.columns[0].content;
-    document.getElementById('content1').innerHTML = label.columns[1].content;
-    document.getElementById('content2').innerHTML = label.columns[2].content;
+    document.getElementById("subtitles").innerHTML = label.subtitles;
+    document.getElementById("content0").innerHTML = label.columns[0].content;
+    document.getElementById("content1").innerHTML = label.columns[1].content;
+    document.getElementById("content2").innerHTML = label.columns[2].content;
 
     if (label.work.is_context_indigenous) {
-      document.getElementById('indigenous').className =
-        'indigenous indigenous_active';
+      document.getElementById("indigenous").className =
+        "indigenous indigenous_active";
     } else {
-      document.getElementById('indigenous').className = 'indigenous';
+      document.getElementById("indigenous").className = "indigenous";
     }
   }
 
   updateUpNextContent(items) {
     // Update up next label
     const item = items[1];
-    document.querySelector('#next_title').innerHTML = item.label.title;
+    document.querySelector("#next_title").innerHTML = item.label.title;
 
     for (let i = 1; i < items.length; i++) {
       const { label } = items[i];
@@ -239,7 +239,7 @@ export default class PlaylistLabelRenderer {
   }
 
   updateProgress() {
-    const progressBar = document.getElementById('progress-bar');
+    const progressBar = document.getElementById("progress-bar");
     const { playbackPosition } = this.state;
     progressBar.style.width = `${playbackPosition * 100}%`;
 
@@ -249,8 +249,8 @@ export default class PlaylistLabelRenderer {
     let timeToWait = items[0].video.duration_secs * (1.0 - playbackPosition);
     for (let i = 1; i < items.length; i++) {
       const numMinutes = parseInt(Math.round(timeToWait / 60.0), 10);
-      let unit = ' minute';
-      if (numMinutes !== 1) unit += 's';
+      let unit = " minute";
+      if (numMinutes !== 1) unit += "s";
 
       const id = `#up_next_label_${i}`;
       try {
@@ -288,19 +288,19 @@ export default class PlaylistLabelRenderer {
       this.state.isAnimatingCollect = true;
 
       // Animation plays: collect -> hidden -> collected -> hidden -> collect
-      const collectElement = document.getElementById('collect');
-      collectElement.className = 'collect hidden';
+      const collectElement = document.getElementById("collect");
+      collectElement.className = "collect hidden";
       window.setTimeout(function timeout1() {
-        collectElement.innerHTML = 'COLLECTED';
-        collectElement.className = 'collect active';
+        collectElement.innerHTML = "COLLECTED";
+        collectElement.className = "collect active";
       }, 500);
       window.setTimeout(function timeout2() {
-        collectElement.className = 'collect active hidden';
+        collectElement.className = "collect active hidden";
       }, 3000);
       window.setTimeout(
         function timeout3() {
-          collectElement.className = 'collect';
-          collectElement.innerHTML = 'COLLECT';
+          collectElement.className = "collect";
+          collectElement.innerHTML = "COLLECT";
           this.state.isAnimatingCollect = false;
         }.bind(this),
         3500
@@ -311,9 +311,9 @@ export default class PlaylistLabelRenderer {
   addTitleAnnotation(work) {
     // If a title_annotation exists, add it to the end of the title
     if (work && work.title_annotation) {
-      const title = document.getElementById('title');
-      const titleAnnotation = document.createElement('span');
-      titleAnnotation.className = 'title_annotation';
+      const title = document.getElementById("title");
+      const titleAnnotation = document.createElement("span");
+      titleAnnotation.className = "title_annotation";
       titleAnnotation.innerHTML = work.title_annotation;
       title.innerHTML = title.innerHTML.replace(
         /<\/p>/g,

--- a/tests/data/message.json
+++ b/tests/data/message.json
@@ -2,7 +2,7 @@
   "datetime": "2019-07-18T17:54:46.633928+10:00",
   "playlist_id": 1,
   "media_player_id": 8,
-  "label_id": 17,
+  "label_id": 51517,
   "playback_position": 0.12073068320751,
   "duration": 93
 }

--- a/tests/data/message_with_title_annotation.json
+++ b/tests/data/message_with_title_annotation.json
@@ -2,7 +2,7 @@
   "datetime": "2019-07-18T17:54:46.633928+10:00",
   "playlist_id": 1,
   "media_player_id": 8,
-  "label_id": 18,
+  "label_id": 44,
   "playback_position": 0.12073068320751,
   "duration": 93
 }

--- a/tests/data/playlist.json
+++ b/tests/data/playlist.json
@@ -1,134 +1,301 @@
 {
   "id": 1,
-  "title": "Demo playlist",
+  "title": "Default playlist",
+  "introduction_title": "About this series",
+  "introduction_content": "",
   "playlist_labels": [
     {
       "label": {
-        "id": 17,
-        "title": "<p>Dracula</p>",
+        "id": 51517,
+        "title": "<p>Test pattern</p>",
+        "type": "Film",
+        "subtitles": "<p>Daniel Bronsema, Lachlan Dickie and Chris Hill, Australia, 2006</p>",
         "columns": [
           {
-            "content": "When Dracula leaves the captive Jonathan Harker and Transylvania for London in search of Mina Harkerâ€”the spitting image of Dracula's long-dead wife, Elisabetaâ€”obsessed vampire hunter, Dr. Van Helsing sets out to end the madness.",
+            "content": "<p>Music video uses video effect, animation and gaming sequences<br>\nGraduate work from RMIT media arts (BA Arts).</p>",
             "style": "standard"
           },
-          {
-            "content": "When Dracula leaves the captive Jonathan Harker and Transylvania for London in search of Mina Harkerâ€”the spitting image of Dracula's long-dead wife, Elisabetaâ€”obsessed vampire hunter, Dr. Van Helsing sets out to end the madness.",
-            "style": "small"
+          { "content": "", "style": "standard" },
+          { "content": "", "style": "smaller" }
+        ],
+        "work": {
+          "id": 110639,
+          "acmi_id": "14423",
+          "title": "Test pattern",
+          "title_annotation": "",
+          "slug": "test-pattern",
+          "creator_credit": "Daniel Bronsema, Lachlan Dickie and Chris Hill",
+          "credit_line": "",
+          "headline_credit": "Australia, 2006",
+          "thumbnail": {
+            "image_url": "file://../../data/sample.jpg",
+            "has_video": false
           },
+          "record_type": "work",
+          "type": "Film",
+          "is_on_display": false,
+          "last_on_display_place": "ACMI Viewing Booths",
+          "last_on_display_date": null,
+          "is_context_indigenous": false,
+          "material_description": "",
+          "unpublished": false,
+          "brief_description": "<p>Music video uses video effect, animation and gaming sequences<br>\nGraduate work from RMIT media arts (BA Arts).</p>",
+          "constellations_primary": [],
+          "constellations_other": [],
+          "recommendations": []
+        },
+        "images": [
           {
-            "content": "When Dracula leaves the captive Jonathan Harker and Transylvania for London in search of Mina Harkerâ€”the spitting image of Dracula's long-dead wife, Elisabetaâ€”obsessed vampire hunter, Dr. Van Helsing sets out to end the madness.",
-            "style": "standard"
+            "id": 11343,
+            "image_file": "file://../../data/sample.jpg",
+            "image_file_thumbnail": "file://../../data/sample.jpg",
+            "image_file_xs": "file://../../data/sample.jpg",
+            "image_file_s": "file://../../data/sample.jpg",
+            "image_file_m": "file://../../data/sample.jpg",
+            "image_file_l": "file://../../data/sample.jpg",
+            "caption": "Test pattern (Chris Hill) still",
+            "credit_line": "",
+            "alt_text": "",
+            "width": 438,
+            "height": 327,
+            "access_level": "View anywhere"
           }
         ],
-        "subtitles": "<p>1992, Dir. Francis Ford Coppola</p>",
-        "rights": "",
-        "work": {
-          "id": 47,
-          "title": "Dracula",
-          "public_images": [
-            {
-                "id": 554,
-                "image_file": "file://../../data/sample.jpg",
-                "thumbnail_url": "file://../../data/sample.jpg.150x150_q85.jpg",
-                "caption": "",
-                "credit_line": "",
-                "width": 1920,
-                "height": 1080
-            }
-          ],
-          "abstract": "",
-          "brief_description": "When Dracula leaves the captive Jonathan Harker and Transylvania for London in search of Mina Harkerâ€”the spitting image of Dracula's long-dead wife, Elisabetaâ€”obsessed vampire hunter, Dr. Van Helsing sets out to end the madness.",
-          "first_production_year": "1992"
-        }
+        "url_override": "",
+        "is_an_event": false
+      },
+      "video": {
+        "id": 1112,
+        "title": "Test pattern 1920x1080 with audio no logo",
+        "resource": "file://../../data/sample.mp4",
+        "web_resource": "file://../../data/sample.mp4",
+        "duration_secs": 30.036,
+        "subtitles": null,
+        "master_metadata": null,
+        "access_metadata": null,
+        "web_metadata": {
+          "width": 1920,
+          "height": 1080,
+          "checksum": "a53a1aa1d6f9443301a7708385f4ca6c",
+          "mime_type": "video/mp4",
+          "audio_codec": "aac",
+          "video_codec": "h264",
+          "duration_hms": "00:30",
+          "duration_secs": 30.036,
+          "audio_bit_rate": 128854,
+          "audio_channels": 2,
+          "video_bit_rate": 64179,
+          "file_size_bytes": 758819,
+          "overall_bit_rate": 202109,
+          "video_frame_rate": 29.97002997002997,
+          "audio_sample_rate": 48000,
+          "creation_datetime": "2020-09-25 22:01:33.410678",
+          "audio_max_bit_rate": 128854,
+          "video_max_bit_rate": null
+        },
+        "access_level": "View anywhere",
+        "snapshot": "file://../../data/sample.jpg",
+        "animated_snapshot": ""
       },
       "resource": "file://../../data/sample.mp4",
-      "subtitles": "file://../../data/sample.srt"
+      "subtitles": null,
+      "region_svg": ""
     },
     {
       "label": {
-        "id": 18,
-        "title": "<p>Jurassic Park</p>",
+        "id": 44,
+        "title": "<p>Placeholder video 1</p>",
+        "type": "work",
+        "subtitles": "<p>Secondary content</p>",
         "columns": [
           {
-            "content": "A wealthy entrepreneur secretly creates a theme park featuring living dinosaurs drawn from prehistoric DNA. Before opening day, he invites a team of experts and his two eager grandchildren to experience the park and help calm anxious investors. However, the park is anything but amusing as the security systems go off-line and the dinosaurs escape.",
+            "content": "<p>This is the first placeholder video for the ACMI media players. On initial startup an unconfigured media player will play a playlist containing this video.</p>",
             "style": "standard"
           },
-          {
-            "content": "A wealthy entrepreneur secretly creates a theme park featuring living dinosaurs drawn from prehistoric DNA. Before opening day, he invites a team of experts and his two eager grandchildren to experience the park and help calm anxious investors. However, the park is anything but amusing as the security systems go off-line and the dinosaurs escape.",
-            "style": "standard"
-          },
-          {
-            "content": "",
-            "style": "standard"
-          }
+          { "content": "", "style": "standard" },
+          { "content": "", "style": "smaller" }
         ],
-        "subtitles": "<p>1993, Dir. Steven Spielberg</p>",
-        "rights": "",
         "work": {
-          "id": 49,
-          "title": "Jurassic Park",
+          "id": 60889,
+          "acmi_id": "xos-60889",
+          "title": "Placeholder video 1",
           "title_annotation": "facsimile",
-          "public_images": [
-            {
-                "id": 554,
-                "image_file": "file://../../data/sample.jpg",
-                "thumbnail_url": "file://../../data/sample.jpg.150x150_q85.jpg",
-                "caption": "",
-                "credit_line": "",
-                "width": 1920,
-                "height": 1080
-            }
-          ],
-          "abstract": "",
-          "brief_description": "A wealthy entrepreneur secretly creates a theme park featuring living dinosaurs drawn from prehistoric DNA. Before opening day, he invites a team of experts and his two eager grandchildren to experience the park and help calm anxious investors. However, the park is anything but amusing as the security systems go off-line and the dinosaurs escape.",
-          "first_production_year": "1993"
-        }
+          "slug": "placeholder-video-1",
+          "creator_credit": "",
+          "credit_line": "",
+          "headline_credit": "Melbourne/VIC/Australia, 2019",
+          "thumbnail": {
+            "image_url": "file://../../data/sample.jpg",
+            "has_video": false
+          },
+          "record_type": "work",
+          "type": "Film",
+          "is_on_display": false,
+          "last_on_display_place": null,
+          "last_on_display_date": null,
+          "is_context_indigenous": false,
+          "material_description": "",
+          "unpublished": false,
+          "brief_description": "<p>This is the first placeholder video for the ACMI media players. On initial startup an unconfigured media player will play a playlist containing this video.</p>",
+          "constellations_primary": [],
+          "constellations_other": [],
+          "recommendations": []
+        },
+        "images": [
+          {
+            "id": 554,
+            "image_file": "file://../../data/sample.jpg",
+            "image_file_thumbnail": "file://../../data/sample.jpg",
+            "image_file_xs": "file://../../data/sample.jpg",
+            "image_file_s": "file://../../data/sample.jpg",
+            "image_file_m": "file://../../data/sample.jpg",
+            "image_file_l": "file://../../data/sample.jpg",
+            "caption": "",
+            "credit_line": "",
+            "alt_text": "",
+            "width": 1920,
+            "height": 1080,
+            "access_level": "View anywhere"
+          }
+        ],
+        "url_override": "",
+        "is_an_event": false
+      },
+      "video": {
+        "id": 1067,
+        "title": "Placeholder video 1 with audio",
+        "resource": "file://../../data/sample.mp4",
+        "web_resource": "file://../../data/sample.mp4",
+        "duration_secs": 30.058,
+        "subtitles": null,
+        "master_metadata": null,
+        "access_metadata": null,
+        "web_metadata": {
+          "width": 1920,
+          "height": 1080,
+          "checksum": "7f1f868fb026caed64b54b98f5212731",
+          "mime_type": "video/mp4",
+          "audio_codec": "aac",
+          "video_codec": "h264",
+          "duration_hms": "00:30",
+          "duration_secs": 30.058,
+          "audio_bit_rate": 126241,
+          "audio_channels": 2,
+          "video_bit_rate": 1950719,
+          "file_size_bytes": 7831159,
+          "overall_bit_rate": 2084279,
+          "video_frame_rate": 29.97002997002997,
+          "audio_sample_rate": 48000,
+          "creation_datetime": "2020-08-31 22:54:58.557279",
+          "audio_max_bit_rate": 128000,
+          "video_max_bit_rate": null
+        },
+        "access_level": "View anywhere",
+        "snapshot": "file://../../data/sample.jpg",
+        "animated_snapshot": ""
       },
       "resource": "file://../../data/sample.mp4",
-      "subtitles": "file://../../data/sample.srt"
+      "subtitles": null,
+      "region_svg": ""
     },
     {
       "label": {
-        "id": 19,
-        "title": "<p>Kiki's Delivery Service</p>",
+        "id": 45,
+        "title": "<p>Placeholder video 2</p>",
+        "type": "work",
+        "subtitles": "<p>Secondary content</p>",
         "columns": [
           {
-            "content": "A young witch, on her mandatory year of independent life, finds fitting into a new community difficult while she supports herself by running an air courier service.",
+            "content": "<p>This is the second placeholder video for the ACMI media players. On initial startup an unconfigured media player will play a playlist containing this video.</p>",
             "style": "standard"
           },
-          {
-            "content": "A wealthy entrepreneur secretly creates a theme park featuring living dinosaurs drawn from prehistoric DNA. Before opening day, he invites a team of experts and his two eager grandchildren to experience the park and help calm anxious investors. However, the park is anything but amusing as the security systems go off-line and the dinosaurs escape.",
-            "style": "standard"
-          },
-          {
-            "content": "",
-            "style": "standard"
-          }
-
+          { "content": "", "style": "standard" },
+          { "content": "", "style": "smaller" }
         ],
-        "subtitles": "<p>1989, Dir. Hayao Miyazaki</p>",
-        "rights": "",
         "work": {
-          "id": 48,
-          "title": "Kiki's Delivery Service",
-          "public_images": [
-            {
-                "id": 554,
-                "image_file": "file://../../data/sample.jpg",
-                "thumbnail_url": "file://../../data/sample.jpg.150x150_q85.jpg",
-                "caption": "",
-                "credit_line": "",
-                "width": 1920,
-                "height": 1080
-            }
-          ],
-          "abstract": "",
-          "brief_description": "A young witch, on her mandatory year of independent life, finds fitting into a new community difficult while she supports herself by running an air courier service.",
-          "first_production_year": "1989"
-        }
+          "id": 60890,
+          "acmi_id": "xos-60890",
+          "title": "Placeholder video 2",
+          "title_annotation": "",
+          "slug": "placeholder-video-2",
+          "creator_credit": "",
+          "credit_line": "",
+          "headline_credit": "Melbourne/VIC/Australia, 2019",
+          "thumbnail": {
+            "image_url": "file://../../data/sample.jpg",
+            "has_video": false
+          },
+          "record_type": "work",
+          "type": "Film",
+          "is_on_display": false,
+          "last_on_display_place": null,
+          "last_on_display_date": null,
+          "is_context_indigenous": false,
+          "material_description": "",
+          "unpublished": false,
+          "brief_description": "<p>This is the second placeholder video for the ACMI media players. On initial startup an unconfigured media player will play a playlist containing this video.</p>",
+          "constellations_primary": [],
+          "constellations_other": [],
+          "recommendations": []
+        },
+        "images": [
+          {
+            "id": 555,
+            "image_file": "file://../../data/sample.jpg",
+            "image_file_thumbnail": "file://../../data/sample.jpg",
+            "image_file_xs": "file://../../data/sample.jpg",
+            "image_file_s": "file://../../data/sample.jpg",
+            "image_file_m": "file://../../data/sample.jpg",
+            "image_file_l": "file://../../data/sample.jpg",
+            "caption": "",
+            "credit_line": "",
+            "alt_text": "",
+            "width": 1920,
+            "height": 1080,
+            "access_level": "View anywhere"
+          }
+        ],
+        "url_override": "",
+        "is_an_event": false
+      },
+      "video": {
+        "id": 1068,
+        "title": "Placeholder video 2 with audio",
+        "resource": "file://../../data/sample.mp4",
+        "web_resource": "file://../../data/sample.mp4",
+        "duration_secs": 20.052,
+        "subtitles": null,
+        "master_metadata": null,
+        "access_metadata": null,
+        "web_metadata": {
+          "width": 1920,
+          "height": 1080,
+          "checksum": "582479747b5d8bd9b6fb93405889b777",
+          "mime_type": "video/mp4",
+          "audio_codec": "aac",
+          "video_codec": "h264",
+          "duration_hms": "00:20",
+          "duration_secs": 20.052,
+          "audio_bit_rate": 129224,
+          "audio_channels": 2,
+          "video_bit_rate": 186167,
+          "file_size_bytes": 813035,
+          "overall_bit_rate": 324370,
+          "video_frame_rate": 29.97002997002997,
+          "audio_sample_rate": 48000,
+          "creation_datetime": "2020-08-31 22:55:54.909910",
+          "audio_max_bit_rate": 129224,
+          "video_max_bit_rate": null
+        },
+        "access_level": "View anywhere",
+        "snapshot": "file://../../data/sample.jpg",
+        "animated_snapshot": ""
       },
       "resource": "file://../../data/sample.mp4",
-      "subtitles": "file://../../data/sample.srt"
+      "subtitles": null,
+      "region_svg": ""
     }
-  ]
+  ],
+  "background": null,
+  "background_dimensions": null
 }

--- a/tests/js/__tests__/playlist.test.js
+++ b/tests/js/__tests__/playlist.test.js
@@ -22,6 +22,12 @@ describe("PlaylistLabelRenderer", () => {
       mqtt_port: "1234",
       mqtt_username: "mqtt_username",
       mqtt_password: "mqtt_password",
+      xos_playlist_endpoint: "https://xos.acmi.net.au/api/playlists/",
+      xos_media_player_id: 8,
+      ignore_tap_reader: "false",
+      ignore_media_player: "true",
+      is_preview: "false",
+      playlist_json: playlistData,
     };
 
     // Set up our document body

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -73,7 +73,7 @@ def test_create_cache(capsys):
         with open(f'{main.CACHE_DIR}playlist_1.json', 'r') as playlist_cache:
             playlist = json.loads(playlist_cache.read())['playlist_labels']
         assert len(playlist) == 3
-        assert playlist[0]['label']['title'] == '<p>Dracula</p>'
+        assert playlist[0]['label']['title'] == '<p>Test pattern</p>'
 
 
 @pytest.mark.usefixtures('database')
@@ -133,7 +133,7 @@ def test_route_playlist_json(client):
     create_cache()
     response = client.get('/api/playlist/')
 
-    assert b'Dracula' in response.data
+    assert b'Test pattern' in response.data
     assert response.status_code == 200
 
 


### PR DESCRIPTION
Resolves #70

Fix linting and test failures resulting from https://github.com/ACMILabs/playlist-label/pull/62

### Acceptance Criteria
- [x] Fix linting and testing from https://github.com/ACMILabs/playlist-label/pull/62

### Relevant design files
* None

### Testing instructions
1. Start the javascript testing server: `cd testing` and `docker-compose up --build`
1. Note that Javascript linting and tests pass: `docker exec -it javascripttests make linttestjs`
2. Start the development server: `cd development` and `docker-compose up --build`
3. Note that Python linting and tests pass: `docker exec -it playlistlabel make linttest`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
