### PR TITLE
#76 Decreased margin between credits and title of 'up_next' layout

### DIFF
--- a/app/static/up_next.style.css
+++ b/app/static/up_next.style.css
@@ -25,7 +25,7 @@
 .title_cont .subtitles {
   font-size: 28px;
   line-height: 39px;
-  margin-top: 54px;
+  margin-top: 12px;
 }
 
 .subtitles p {


### PR DESCRIPTION
Resolves #76

Allowed a larger area for credits, by decreasing the margin between credits and the title.

### Acceptance Criteria
- [x] Layout allows for arbitrarily large credit fields (see design files).

### Relevant design files
* https://github.com/ACMILabs/playlist-label/issues/76

### Testing instructions
Add a list of steps required to test the feature.
1. Edit the config.env file, set the 'XOS_PLAYLIST_ID' to '86'.
2. Start the playlist-label (and navigate to it localhost:8081)
3. Note the layout matches the intended design

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
~- [ ] Changelog has been updated if necessary~
~- [ ] Deployment / migration instruction have been updated if required~
