### PR TITLE
#84 Add a countdown template

### DIFF
--- a/app/static/countdown.style.css
+++ b/app/static/countdown.style.css
@@ -1,0 +1,27 @@
+
+.container {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  padding-top: 10%;
+  font-size: 7rem;
+  line-height: 8rem;
+}
+
+#left_heading {
+  width: 55%;
+  float: left;
+  font-family: PxGrotesk;
+}
+
+#right_heading {
+  width: 45%;
+  float: right;
+  font-family: FaktPro;
+}
+
+.progress-bar {
+    background-color: rgb(249, 213, 72);
+    height: 2.5rem;
+}

--- a/app/static/countdown.style.css
+++ b/app/static/countdown.style.css
@@ -1,24 +1,30 @@
+html, body {
+    height: 100%;
+}
 
 .container {
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  text-align: center;
-  padding-top: 10%;
-  font-size: 7rem;
-  line-height: 8rem;
+    display: table;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    font-size: 7rem;
+    line-height: 8rem;
 }
 
 #left_heading {
-  width: 55%;
-  float: left;
-  font-family: PxGrotesk;
+    display: table-cell;
+    vertical-align: middle;
+    height: 100%;
+    width: 55%;
+    font-family: PxGrotesk;
 }
 
 #right_heading {
-  width: 45%;
-  float: right;
-  font-family: FaktPro;
+    display: table-cell;
+    vertical-align: middle;
+    height: 100%;
+    width: 45%;
+    font-family: FaktPro;
 }
 
 .progress-bar {

--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -269,7 +269,7 @@ export default class PlaylistLabelRenderer {
       if (timeToWait < 60) {
         countdownTime = parseInt(Math.round(timeToWait), 10);
         countdownUnit = " second";
-        if (countdownTime % 10 !== 0 || countdownTime == 0) {
+        if (countdownTime % 10 !== 0 || countdownTime === 0) {
           updateCountdownTime = false;
         }
       }

--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -209,18 +209,22 @@ export default class PlaylistLabelRenderer {
   updateMainLabelContent(item) {
     const { label } = item;
     // Update the label fields with the currently playing data
-    document.getElementById("title").innerHTML = label.title;
-    this.addTitleAnnotation(label.work);
-    document.getElementById("subtitles").innerHTML = label.subtitles;
-    document.getElementById("content0").innerHTML = label.columns[0].content;
-    document.getElementById("content1").innerHTML = label.columns[1].content;
-    document.getElementById("content2").innerHTML = label.columns[2].content;
+    try {
+      document.getElementById("title").innerHTML = label.title;
+      this.addTitleAnnotation(label.work);
+      document.getElementById("subtitles").innerHTML = label.subtitles;
+      document.getElementById("content0").innerHTML = label.columns[0].content;
+      document.getElementById("content1").innerHTML = label.columns[1].content;
+      document.getElementById("content2").innerHTML = label.columns[2].content;
 
-    if (label.work.is_context_indigenous) {
-      document.getElementById("indigenous").className =
-        "indigenous indigenous_active";
-    } else {
-      document.getElementById("indigenous").className = "indigenous";
+      if (label.work.is_context_indigenous) {
+        document.getElementById("indigenous").className =
+          "indigenous indigenous_active";
+      } else {
+        document.getElementById("indigenous").className = "indigenous";
+      }
+    } catch (error) {
+      // Pass for a countdown template without a title element
     }
   }
 
@@ -252,17 +256,23 @@ export default class PlaylistLabelRenderer {
 
     // calculate time to wait times for the upcoming videos;
     let timeToWait = items[0].video.duration_secs * (1.0 - playbackPosition);
-    for (let i = 1; i < items.length; i++) {
-      const numMinutes = parseInt(Math.round(timeToWait / 60.0), 10);
-      let unit = " minute";
-      if (numMinutes !== 1) unit += "s";
+    const numMinutes = parseInt(Math.round(timeToWait / 60.0), 10);
+    let unit = " minute";
+    if (numMinutes !== 1) unit += "s";
 
+    try {
+      // Set countdown timer minutes remaining
+      document.querySelector("#minutes_remaining").innerHTML = numMinutes;
+      document.querySelector("#units").innerHTML = unit;
+    } catch (error) {
+      // continue regardless of error
+    }
+
+    for (let i = 1; i < items.length; i++) {
       const id = `#up_next_label_${i}`;
       try {
         document.querySelector(`${id} .time_to_wait`).innerHTML =
           numMinutes + unit;
-        document.querySelector('#minutes_remaining').innerHTML = numMinutes;
-        document.querySelector('#units').innerHTML = unit;
       } catch (error) {
         // continue regardless of error
       }
@@ -319,14 +329,18 @@ export default class PlaylistLabelRenderer {
   addTitleAnnotation(work) {
     // If a title_annotation exists, add it to the end of the title
     if (work && work.title_annotation) {
-      const title = document.getElementById("title");
-      const titleAnnotation = document.createElement("span");
-      titleAnnotation.className = "title_annotation";
-      titleAnnotation.innerHTML = work.title_annotation;
-      title.innerHTML = title.innerHTML.replace(
-        /<\/p>/g,
-        `${titleAnnotation.outerHTML}</p>`
-      );
+      try {
+        const title = document.getElementById("title");
+        const titleAnnotation = document.createElement("span");
+        titleAnnotation.className = "title_annotation";
+        titleAnnotation.innerHTML = work.title_annotation;
+        title.innerHTML = title.innerHTML.replace(
+          /<\/p>/g,
+          `${titleAnnotation.outerHTML}</p>`
+        );
+      } catch (error) {
+        // Pass for a countdown template without a title element
+      }
     }
   }
 }

--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -261,6 +261,8 @@ export default class PlaylistLabelRenderer {
       try {
         document.querySelector(`${id} .time_to_wait`).innerHTML =
           numMinutes + unit;
+        document.querySelector('#minutes_remaining').innerHTML = numMinutes;
+        document.querySelector('#units').innerHTML = unit;
       } catch (error) {
         // continue regardless of error
       }

--- a/app/static/playlist.js
+++ b/app/static/playlist.js
@@ -262,8 +262,22 @@ export default class PlaylistLabelRenderer {
 
     try {
       // Set countdown timer minutes remaining
-      document.querySelector("#minutes_remaining").innerHTML = numMinutes;
-      document.querySelector("#units").innerHTML = unit;
+      let countdownTime = numMinutes;
+      let countdownUnit = " minute";
+      if (countdownTime !== 1) unit += "s";
+      let updateCountdownTime = true;
+      if (timeToWait < 60) {
+        countdownTime = parseInt(Math.round(timeToWait), 10);
+        countdownUnit = " second";
+        if (countdownTime % 10 !== 0 || countdownTime == 0) {
+          updateCountdownTime = false;
+        }
+      }
+      if (countdownTime !== 1) countdownUnit += "s";
+      if (updateCountdownTime) {
+        document.querySelector("#minutes_remaining").innerHTML = countdownTime;
+        document.querySelector("#units").innerHTML = countdownUnit;
+      }
     } catch (error) {
       // continue regardless of error
     }

--- a/app/templates/countdown.html
+++ b/app/templates/countdown.html
@@ -1,0 +1,29 @@
+{% extends "_base.html" %}
+
+{% block title %}Countdown timer for Playlist: {{ playlist_json.title }}{% endblock %}
+{% block stylesheet %}/static/countdown.style.css{% endblock %}
+{% block bodyclass %}countdown{% endblock %}
+
+{% block body %}
+{% if not playlist_json or playlist_json.playlist_labels|length == 0 %}
+    <div class='container'>
+        <div id="left_heading">
+            <div class='title'>Playlist has no labels 😭</div>
+        </div>
+    </div>
+{% else %}
+    <div class='container'>
+        <div id="left_heading">
+            <div class='title'><p>Restarting<br>in</p></div>
+        </div>
+        <div id="right_heading">
+            <div class='title'><p><span id="minutes_remaining">0:00</span><br><span id="units">minutes</span></p></div>
+        </div>
+    </div>
+    {% if playlist_json.playlist_labels|length > 0 %}
+        <div class='progress-bar-container full-width-progress'>
+            <div id='progress-bar' class='progress-bar'></div>
+        </div>
+    {% endif %}
+{% endif %}
+{% endblock body %}


### PR DESCRIPTION
Resolves #84

Build a template for The Core (You will see me) countdown timer Playlist Label.

### Acceptance Criteria
- [x] Add `countdown.html` template
- [ ] Sync `js` with XOS preview

### Relevant design files
![](https://trello-attachments.s3.amazonaws.com/60580e119c8816868b9115c9/283x148/dcad39ff3f1cf0963be8475c703d72c8/YWSM_countdown_timer_-__Restarting__%281%29.png)

### Screenshot
![Screen Shot 2021-06-02 at 11 20 26 am](https://user-images.githubusercontent.com/314298/120414065-880e0e80-c398-11eb-8279-d912d22d2724.png)

### Testing instructions
1. Set `LABEL_TEMPLATE=countdown.html` in your `config.env`
1. Set `XOS_PLAYLIST_ID=141` to get The Core Playlist
1. Set `XOS_MEDIA_PLAYER_ID=9999999`
1. Setup a media player to point to that playlist, with that media player ID.
1. Load: http://localhost:8081
1. Check that `up_next.html` template still works as expected
1. Check that the default template still works as expected
1. Add a real device to: [s__playlist-label-pi-4](https://dashboard.balena-cloud.com/apps/1529802/summary)
1. See that it functions as the dev device does

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
~- [ ] Changelog has been updated if necessary~
~- [ ] Deployment / migration instruction have been updated if required~
